### PR TITLE
Makefile: add '$(BUILDDIR)' creation in sf2 copy rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ ifneq ($(BUILDOPENGL), no)
 endif
 
 $(BUILDDIR)%.sf2:
+	@mkdir -p $(BUILDDIR)
 	cp -v sf2/$(*F).sf2 $@
 
 FLUID_SRC = \


### PR DESCRIPTION
Noticed missing target directory dependency as a build failure in
`make --shuffle` mode (added in https://savannah.gnu.org/bugs/index.php?62100):

    cp -v sf2/Black_Pearl_4_LV2.sf2 build/Black_Pearl_4_LV2.sf2
    'sf2/Black_Pearl_4_LV2.sf2' -> 'build/Black_Pearl_4_LV2.sf2'
    cp: cannot create regular file 'build/Black_Pearl_4_LV2.sf2': No such file or directory
    make: *** [Makefile:233: build/Black_Pearl_4_LV2.sf2] Error 1 shuffle=1656755041

The change adds directory creation command similar to most other rules.